### PR TITLE
password no longer required, rcon fixed, graceful shutdown added

### DIFF
--- a/.github/workflows/build_image_on_pullrequest.yaml
+++ b/.github/workflows/build_image_on_pullrequest.yaml
@@ -21,7 +21,6 @@ jobs:
           file: Containerfile
           push: false
           build-args: |
-            IMAGE_VERSION=${{ github.event.release.tag_name }}
+            IMAGE_VERSION=test
           tags: |
-            ${{ secrets.DOCKER_USER }}/ark-ascended-server:latest
-            ${{ secrets.DOCKER_TOKEN }}/ark-ascended-server-${{ github.event.release.tag_name }}
+            ${{ secrets.DOCKER_USER }}/ark-ascended-server:test

--- a/.github/workflows/build_image_on_pullrequest.yaml
+++ b/.github/workflows/build_image_on_pullrequest.yaml
@@ -12,8 +12,8 @@ jobs:
       - name: Login to Docker Hub
         uses: docker/login-action@v3
         with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
+          username: ${{ secrets.DOCKER_USER }}
+          password: ${{ secrets.DOCKER_TOKEN }}
       - name: Build
         uses: docker/build-push-action@v6
         with:
@@ -23,5 +23,5 @@ jobs:
           build-args: |
             IMAGE_VERSION=${{ github.event.release.tag_name }}
           tags: |
-            ${{ secrets.DOCKERHUB_USERNAME }}/ark-ascended-server:latest
-            ${{ secrets.DOCKERHUB_USERNAME }}/ark-ascended-server-${{ github.event.release.tag_name }}
+            ${{ secrets.DOCKER_USER }}/ark-ascended-server:latest
+            ${{ secrets.DOCKER_TOKEN }}/ark-ascended-server-${{ github.event.release.tag_name }}

--- a/.github/workflows/build_image_on_pullrequest.yaml
+++ b/.github/workflows/build_image_on_pullrequest.yaml
@@ -1,7 +1,7 @@
-name: Build and push Docker image
+name: Build image on pull-request
 on:
-  release:
-    types: [published]
+  pull_request:
+    types: [opened, synchronize]
 
 jobs:
   build-push:
@@ -14,12 +14,12 @@ jobs:
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
-      - name: Build and push
+      - name: Build
         uses: docker/build-push-action@v6
         with:
           context: "{{defaultContext}}:/container"
           file: Containerfile
-          push: true
+          push: false
           build-args: |
             IMAGE_VERSION=${{ github.event.release.tag_name }}
           tags: |

--- a/.github/workflows/publish_image.yaml
+++ b/.github/workflows/publish_image.yaml
@@ -12,8 +12,8 @@ jobs:
       - name: Login to Docker Hub
         uses: docker/login-action@v3
         with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
+          username: ${{ secrets.DOCKER_USER }}
+          password: ${{ secrets.DOCKER_TOKEN }}
       - name: Build and push
         uses: docker/build-push-action@v6
         with:
@@ -23,5 +23,5 @@ jobs:
           build-args: |
             IMAGE_VERSION=${{ github.event.release.tag_name }}
           tags: |
-            ${{ secrets.DOCKERHUB_USERNAME }}/ark-ascended-server:latest
-            ${{ secrets.DOCKERHUB_USERNAME }}/ark-ascended-server-${{ github.event.release.tag_name }}
+            ${{ secrets.DOCKER_USER }}/ark-ascended-server:latest
+            ${{ secrets.DOCKER_TOKEN }}/ark-ascended-server-${{ github.event.release.tag_name }}

--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ HASH := $(shell git rev-parse --short HEAD)
 CONTAINER_NAME := "ark-ascended-test"
 VOLUME_NAME := "persistent-data-test"
 BUILDAH_BUILD_OPTS := --format docker -f ./container/Containerfile
-PODMAN_RUN_OPTS := --name $(CONTAINER_NAME) -d --mount type=volume,source=$(VOLUME_NAME),target=/home/steam/ark/ShooterGame/Saved -p 7777:7777/udp -p 27020:27020/tcp --env=SESSION_NAME='Ark Containerized Server Test' --env=SERVER_MAP='TheIsland_WP' --env=SERVER_PASSWORD='PleaseChangeMe' --env=SERVER_ADMIN_PASSWORD='AlcoChangeMe' --env=GAME_PORT=7777 --env=RCON_PORT=27020
+PODMAN_RUN_OPTS := --name $(CONTAINER_NAME) -d --mount type=volume,source=$(VOLUME_NAME),target=/home/steam/ark/ShooterGame/Saved -p 7777:7777/udp -p 27020:27020/tcp --env=SESSION_NAME='Ark Containerized Server Test' --env=SERVER_MAP='TheIsland_WP' --env=SERVER_PASSWORD='PleaseChangeMe' --env=SERVER_ADMIN_PASSWORD='AlsoChangeMe' --env=GAME_PORT=7777 --env=RCON_PORT=27020
 
 # Makefile targets
 .PHONY: build run cleanup

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ If you are still running into issues, there is one potential cause that may be o
 | ---- | ----------- | ------- | -------- |
 | SERVER_MAP | The map that the server runs | TheIsland_WP | True |
 | SESSION_NAME | The name for you server/session | None | True |
-| SERVER_PASSWORD | The password to join your server | None | True |
+| SERVER_PASSWORD | The password to join your server | None | False |
 | SERVER_ADMIN_PASSWORD | The password for utilizing admin functions | None | True |
 | GAME_PORT | This is the port that the server accepts incoming traffic on | 7777 | True |
 | RCON_PORT | The port for the RCON service to listen on | 27020 | False |

--- a/container/Containerfile
+++ b/container/Containerfile
@@ -1,5 +1,8 @@
 FROM debian:12-slim
 
+ARG IMAGE_VERSION="v1.0.0-devel"
+ARG MAINTAINER="https://github.com/jsknnr/ark-ascended-server"
+
 ARG CONTAINER_GID=10000
 ARG CONTAINER_UID=10000
 
@@ -25,16 +28,23 @@ RUN groupadd -g $CONTAINER_GID steam \
         wget \
         locales \
         lib32gcc-s1 \
+        procps \
         steamcmd \
         winbind \
         dbus \
         libfreetype6 \
+        net-tools \
     && echo 'LANG="en_US.UTF-8"' > /etc/default/locale \
     && echo "en_US.UTF-8 UTF-8" >> /etc/locale.gen \
     && locale-gen \
     && rm -f /etc/machine-id \
     && dbus-uuidgen --ensure=/etc/machine-id \
     && ln -s /usr/games/steamcmd /usr/bin/steamcmd \
+    && wget https://github.com/gorcon/rcon-cli/releases/download/v0.10.3/rcon-0.10.3-amd64_linux.tar.gz \
+    && tar xzf rcon-0.10.3-amd64_linux.tar.gz \
+    && rm -f rcon-0.10.3-amd64_linux.tar.gz \
+    && mv rcon-0.10.3-amd64_linux/rcon /usr/local/bin \
+    && rm -rf ./rcon-0.10.3-amd64_linux \
     && rm -rf /var/lib/apt/lists/* \
     && apt-get clean \
     && apt-get autoremove -y
@@ -53,7 +63,10 @@ RUN mkdir "$ARK_PATH" \
     && ln -s "${HOME}/.steam/sdk64/steamclient.so" "${HOME}/.steam/sdk64/steamservice.so" \
     && wget "$GE_PROTON_URL" -O "/home/steam/GE-Proton${GE_PROTON_VERSION}.tgz" \
     && tar -x -C "${STEAM_PATH}/compatibilitytools.d/" -f "/home/steam/GE-Proton${GE_PROTON_VERSION}.tgz" \
-    && rm "/home/steam/GE-Proton${GE_PROTON_VERSION}.tgz"
+    && rm "/home/steam/GE-Proton${GE_PROTON_VERSION}.tgz" \
+    && echo "${IMAGE_VERSION}" > /home/steam/image_version \
+    && echo "${MAINTAINER}" > /home/steam/image_maintainer \
+    && echo "${CONTAINER_UID}:${CONTAINER_GID}" > /home/steam/expected_filesystem_permissions
     
 COPY entrypoint.sh /home/steam/entrypoint.sh
 

--- a/container/entrypoint.sh
+++ b/container/entrypoint.sh
@@ -5,6 +5,33 @@ timestamp () {
   date +"%Y-%m-%d %H:%M:%S,%3N"
 }
 
+# Shutdown function for trap
+shutdown () {
+    echo "$(timestamp) INFO: Recieved SIGTERM, shutting down gracefully"
+    echo "$(timestamp) INFO: Saving world..."
+    # Not clear if DoExit saves first so explicitly save then exit
+    rcon -a 127.0.0.1:${RCON_PORT} -p "${SERVER_ADMIN_PASSWORD}" Saveworld
+    rcon -a 127.0.0.1:${RCON_PORT} -p "${SERVER_ADMIN_PASSWORD}" DoExit
+
+    # Server exit doesn't close pid for some reason, so lets check that the port is closed and then send SIGTERM to main pid
+    while netstat -aln | grep -q $GAME_PORT; do
+        sleep 1
+    done
+
+    echo "$(timestamp) INFO: Goodbye"
+    kill -15 $asa_pid 
+}
+
+# Set our trap
+trap 'shutdown' TERM
+
+# Set vars established during image build
+IMAGE_VERSION=$(cat /home/steam/image_version)
+MAINTAINER=$(cat /home/steam/image_maintainer)
+EXPECTED_FS_PERMS=$(cat /home/steam/expected_filesystem_permissions)
+
+echo "$(timestamp) INFO: Launching Ark: Survival Ascended dedicated server image ${IMAGE_VERSION} by ${MAINTAINER}"
+
 # Make sure required arguments are set
 if [ -z "$SERVER_MAP" ]; then
     SERVER_MAP="TheIsland_WP"
@@ -21,9 +48,13 @@ if [ -z "$GAME_PORT" ]; then
     echo "$(timestamp) WARN: GAME_PORT not set, using default: $GAME_PORT UDP"
 fi
 
+if [ -z "$RCON_PORT" ]; then
+    RCON_PORT="27020"
+    echo "$(timestamp) WARN: RCON_PORT not set, using default: $RCON_PORT TCP"
+fi
+
 if [ -z "$SERVER_PASSWORD" ]; then
-    echo "$(timestamp) ERROR: SERVER_PASSWORD environment variable must be set"
-    exit 1
+    echo "$(timestamp) WARN: SERVER_PASSWORD not set, the server will be open to the public"
 fi
 
 if [ -z "$SERVER_ADMIN_PASSWORD" ]; then
@@ -35,8 +66,8 @@ fi
 if ! touch "${ARK_PATH}/ShooterGame/Saved/test"; then
     echo ""
     echo "$(timestamp) ERROR: The ownership of /home/steam/ark/ShooterGame/Saved is not correct and the server will not be able to save..."
-    echo "the directory that you are mounting into the container needs to be owned by 10000:10000 (by default)"
-    echo "from your container host attempt the following command 'chown -R 10000:10000 /your/ark/folder'"
+    echo "the directory that you are mounting into the container needs to be owned by ${EXPECTED_FS_PERMS}"
+    echo "from your container host attempt the following command 'chown -R ${EXPECTED_FS_PERMS} /your/ark/folder'"
     echo ""
     exit 1
 fi
@@ -68,15 +99,20 @@ fi
 ln -sf /proc/1/fd/1 "${ARK_PATH}/ShooterGame/Saved/Logs/ShooterGame.log"
 
 # Build Ark Ascended launch command
-LAUNCH_COMMAND="${SERVER_MAP}?SessionName=${SESSION_NAME}?Port=${GAME_PORT}?ServerPassword=${SERVER_PASSWORD}?ServerAdminPassword=${SERVER_ADMIN_PASSWORD}"
-
-if [ -n "${RCON_PORT}" ]; then
-    LAUNCH_COMMAND="${LAUNCH_COMMAND}?RCONEnabled=True?RCONPort=${RCON_PORT}"
+LAUNCH_COMMAND="${SERVER_MAP}?SessionName=${SESSION_NAME}?RCONEnabled=True?RCONPort=${RCON_PORT}"
+if [ -n "${SERVER_PASSWORD}" ]; then
+    LAUNCH_COMMAND="${LAUNCH_COMMAND}?ServerPassword=${SERVER_PASSWORD}"
 fi
 
 if [ -n "${EXTRA_SETTINGS}" ]; then
     LAUNCH_COMMAND="${LAUNCH_COMMAND}${EXTRA_SETTINGS}"
 fi
+
+# According to Wiki, ServerAdminPassword must be the last "?" deliniated Argument
+LAUNCH_COMMAND="${LAUNCH_COMMAND}?ServerAdminPassword=${SERVER_ADMIN_PASSWORD}"
+
+# According to Wiki, game port is not a ? deliniated command
+LAUNCH_COMMAND="${LAUNCH_COMMAND} -port=${GAME_PORT}"
 
 if [ -n "${EXTRA_FLAGS}" ]; then
     LAUNCH_COMMAND="${LAUNCH_COMMAND} ${EXTRA_FLAGS}"
@@ -86,15 +122,59 @@ if [ -n "${MODS}" ]; then
     LAUNCH_COMMAND="${LAUNCH_COMMAND} -mods=${MODS}"
 fi
 
+# RCONEnabled in server start args doesn't seem to actually enabled RCON, so let's do it manually
+if ! [ -f "${ARK_PATH}/ShooterGame/Saved/Config/WindowsServer/GameUserSettings.ini" ]; then
+    mkdir -p ${ARK_PATH}/ShooterGame/Saved/Config/WindowsServer
+    cat <<EOF > ${ARK_PATH}/ShooterGame/Saved/Config/WindowsServer/GameUserSettings.ini
+[ServerSettings]
+RCONEnabled=True
+RCONPort=${RCON_PORT}
+EOF
+elif [ ! grep "RCONEnabled" ${ARK_PATH}/ShooterGame/Saved/Config/WindowsServer/GameUserSettings.ini ]; then
+    sed -i "s/RCONPort=[0-9]*/RCONPort=${RCON_PORT}\nRCONEnabled=True/" ${ARK_PATH}/ShooterGame/Saved/Config/WindowsServer/GameUserSettings.ini
+elif [ grep "RCONEnabled=False" ${ARK_PATH}/ShooterGame/Saved/Config/WindowsServer/GameUserSettings.ini ]; then
+    sed -i "s/RCONEnabled=False/RCONEnabled=True/" ${ARK_PATH}/ShooterGame/Saved/Config/WindowsServer/GameUserSettings.ini
+fi
+
+echo ""
+echo "   _____         __                                        "
+echo "  /  _  \_______|  | __                                    "
+echo " /  /_\  \_  __ \  |/ /                                    "
+echo "/    |    \  | \/    <                                     "
+echo "\____|__  /__|  |__|_ \                                    "
+echo "        \/           \/                                    "
+echo "  _________                  .__              .__          "
+echo " /   _____/__ ____________  _|__|__  _______  |  |         "
+echo " \_____  \|  |  \_  __ \  \/ /  \  \/ /\__  \ |  |         "
+echo " /        \  |  /|  | \/\   /|  |\   /  / __ \|  |__       "
+echo "/_______  /____/ |__|    \_/ |__| \_/  (____  /____/       "
+echo "        \/                                  \/             "
+echo "   _____                                  .___         .___"
+echo "  /  _  \   ______ ____  ____   ____    __| _/____   __| _/"
+echo " /  /_\  \ /  ___// ___\/ __ \ /    \  / __ |/ __ \ / __ | "
+echo "/    |    \\\___ \\\  \__\  ___/|   |  \/ /_/ \  ___// /_/ | "
+echo "\____|__  /____  >\___  >___  >___|  /\____ |\___  >____ | "
+echo "        \/     \/     \/    \/     \/      \/    \/     \/ "
+echo "                                                           "
+echo "                                                           "
+echo "$(timestamp) INFO: Launching ARK:SA"
+echo "-----------------------------------------------------------"
+echo "Server Name: ${SESSION_NAME}"
+echo "Server Password: ${SERVER_PASSWORD}"
+echo "Admin Password: ${SERVER_ADMIN_PASSWORD}"
+echo "RCON Port: ${RCON_PORT}"
+echo "Game Port: ${GAME_PORT}"
+echo "Map: ${SERVER_MAP}"
+echo "Extra Settings: ${EXTRA_SETTINGS}"
+echo "Extra Flags: ${EXTRA_FLAGS}"
+echo "Mods: ${MODS}"
+echo "Server Container Image Version: ${IMAGE_VERSION}"
+echo ""
+echo ""
+
 # Launch ASE Server in Proton
-echo "$(timestamp) INFO: Starting Ark Survival Ascended dedicated server"
-${STEAM_PATH}/compatibilitytools.d/GE-Proton${GE_PROTON_VERSION}/proton run ${ARK_PATH}/ShooterGame/Binaries/Win64/ArkAscendedServer.exe ${LAUNCH_COMMAND}
+${STEAM_PATH}/compatibilitytools.d/GE-Proton${GE_PROTON_VERSION}/proton run ${ARK_PATH}/ShooterGame/Binaries/Win64/ArkAscendedServer.exe ${LAUNCH_COMMAND} &
 
-# Capture Proton process pid that launches ASA
-ASE_PID=$!
+asa_pid=$!
 
-# If pid closes, we close
-wait $ASE_PID
-
-echo "$(timestamp) WARN: ASA dedicated server pid has closed, exitting container"
-exit 0
+wait $asa_pid


### PR DESCRIPTION
- no longer required server password
- rconenabled server start flag doesn't actually enable rcon, so enable it manually
- added graceful shutdown via sigterm trap and rcon save and exit on server
- switched from Buildah to Docker buildx as some folks have reported issues with buildah images on older versions of Docker with Ubuntu 22.04