### PR TITLE
Remove test file after Steam update

### DIFF
--- a/container/entrypoint.sh
+++ b/container/entrypoint.sh
@@ -72,9 +72,6 @@ if ! touch "${ARK_PATH}/ShooterGame/Saved/test"; then
     exit 1
 fi
 
-# Cleanup test write
-rm "${ARK_PATH}/ShooterGame/Saved/test"
-
 # Update Ark Ascended
 echo "$(timestamp) INFO: Updating Ark Survival Ascended Dedicated Server"
 steamcmd +@sSteamCmdForcePlatformType windows +force_install_dir "$ARK_PATH" +login anonymous +app_update 2430930 validate +quit
@@ -84,6 +81,9 @@ if [ $? != 0 ]; then
     echo "$(timestamp) ERROR: steamcmd was unable to successfully initialize and update Ark Survival Ascended Dedicated Server"
     exit 1
 fi
+
+# Cleanup test write
+rm "${ARK_PATH}/ShooterGame/Saved/test"
 
 # Check that log directory exists, if not create
 if ! [ -d "${ARK_PATH}/ShooterGame/Saved/Logs/" ]; then


### PR DESCRIPTION
This seems like a really silly change, but it is the least impactful way to update the startup script to support Kubernetes healthchecks.

The issue with healthchecks and game servers that update themselves is that it is hard to calculate how long it should take before the healthcheck starts and the container will usually get killed before the update is complete. Keeping the test file in place until _after_ the update, will allow something like this for kubernetes:

```yml
livenessProbe:
  tcpSocket:
    port: rcon
  initialDelaySeconds: 5 # how long it takes rcon port to start listening
  timeoutSeconds: 1
  periodSeconds: 5
  failureThreshold: 3
  successThreshold: 1
readinessProbe:
  exec:
    command:
    - sh
    - -c
    - rcon -a 127.0.0.1:${RCON_PORT} -p ${SERVER_ADMIN_PASSWORD} listplayers
  initialDelaySeconds: 5 # how long after the rcon port starts listening the game server is "online"
  timeoutSeconds: 1
  periodSeconds: 5
  failureThreshold: 3
  successThreshold: 1
startupProbe:
  exec:
    command:
      - sh
      - -c
      - test ! -f "${ARK_PATH}/ShooterGame/Saved/test"
```

This will _wait_ until the test file is removed (updates are complete) and then start checking port 7777 for liveness, then start checking rcon for readiness. 