### PR TITLE
Improve update process

### DIFF
--- a/container/entrypoint.sh
+++ b/container/entrypoint.sh
@@ -73,7 +73,7 @@ if ! touch "${ARK_PATH}/ShooterGame/Saved/.perm-test"; then
 fi
 
 # Cleanup test write
-rm "${ARK_PATH}/ShooterGame/Saved/.perm-test"
+rm -f "${ARK_PATH}/ShooterGame/Saved/.perm-test"
 
 
 AUTO_UPDATE=${AUTO_UPDATE:-true}
@@ -85,26 +85,14 @@ mkdir -p "${ARK_SAVE_PATH}"
 touch "${ARK_SAVE_PATH}/.pre-setup"
 
 if [ "$AUTO_UPDATE" == "true" ]; then
-    if [ -f "${ARK_PATH}/ShooterGame/.update-lock" ]; then
-        echo "$(timestamp) INFO: Another instance is updating Ark Survival Ascended Dedicated Server"
-        while [ -f "${ARK_PATH}/ShooterGame/.update-lock" ]; do
-            echo "$(timestamp) INFO: Waiting for Update Completion"
-            sleep 10
-        done
-    else
-        touch "${ARK_PATH}/ShooterGame/.update-lock"
+    # Update Ark Ascended
+    echo "$(timestamp) INFO: Updating Ark Survival Ascended Dedicated Server"
+    steamcmd +@sSteamCmdForcePlatformType windows +force_install_dir "$ARK_PATH" +login anonymous +app_update 2430930 validate +quit
 
-        # Update Ark Ascended
-        echo "$(timestamp) INFO: Updating Ark Survival Ascended Dedicated Server"
-        steamcmd +@sSteamCmdForcePlatformType windows +force_install_dir "$ARK_PATH" +login anonymous +app_update 2430930 validate +quit
-
-        # Check that steamcmd was successful
-        if [ $? != 0 ]; then
-            echo "$(timestamp) ERROR: steamcmd was unable to successfully initialize and update Ark Survival Ascended Dedicated Server"
-            exit 1
-        fi
-
-        rm "${ARK_PATH}/ShooterGame/.update-lock"
+    # Check that steamcmd was successful
+    if [ $? != 0 ]; then
+        echo "$(timestamp) ERROR: steamcmd was unable to successfully initialize and update Ark Survival Ascended Dedicated Server"
+        exit 1
     fi
 else
     echo "$(timestamp) INFO: Skiping Update for Ark Survival Ascended Dedicated Server"

--- a/container/entrypoint.sh
+++ b/container/entrypoint.sh
@@ -81,6 +81,7 @@ LOG_FILENAME="ShooterGame_${SERVER_MAP}"
 ARK_SAVE_PATH="${ARK_PATH}/ShooterGame/Saved/SavedArks/${SERVER_MAP}"
 
 # can be used by startup healthcheck probes
+mkdir -p "${ARK_SAVE_PATH}"
 touch "${ARK_SAVE_PATH}/.pre-setup"
 
 if [ "$AUTO_UPDATE" == "true" ]; then

--- a/container/entrypoint.sh
+++ b/container/entrypoint.sh
@@ -77,7 +77,6 @@ rm -f "${ARK_PATH}/ShooterGame/Saved/.perm-test"
 
 
 AUTO_UPDATE=${AUTO_UPDATE:-true}
-LOG_FILENAME="ShooterGame_${SERVER_MAP}"
 ARK_SAVE_PATH="${ARK_PATH}/ShooterGame/Saved/SavedArks/${SERVER_MAP}"
 
 # can be used by startup healthcheck probes
@@ -104,12 +103,12 @@ if ! [ -d "${ARK_PATH}/ShooterGame/Saved/Logs/" ]; then
 fi
 
 # Check that log file exists, if not create
-if ! [ -f "${ARK_PATH}/ShooterGame/Saved/Logs/${LOG_FILENAME}.log" ]; then
-    touch "${ARK_PATH}/ShooterGame/Saved/Logs/${LOG_FILENAME}.log"
+if ! [ -f "${ARK_PATH}/ShooterGame/Saved/Logs/ShooterGame.log" ]; then
+    touch "${ARK_PATH}/ShooterGame/Saved/Logs/ShooterGame.log"
 fi
 
 # Link logfile to stdout of pid 1 so we can see logs
-ln -sf /proc/1/fd/1 "${ARK_PATH}/ShooterGame/Saved/Logs/${LOG_FILENAME}.log"
+ln -sf /proc/1/fd/1 "${ARK_PATH}/ShooterGame/Saved/Logs/ShooterGame.log"
 
 # Build Ark Ascended launch command
 LAUNCH_COMMAND="${SERVER_MAP}?SessionName=${SESSION_NAME}?RCONEnabled=True?RCONPort=${RCON_PORT}"


### PR DESCRIPTION
### Summary

Goal of this PR is to accomplish two things:

* Optional updates
* Support for "startup" healthcheck probes

### Optional Updates

Adds an env so updates can be optionally performed. Good if servers need to lock to a specific version for some reason. This works great in a cluster because then only one server needs to manage the updates.

### Support Startup Probes

Updates take an unknown amount of time. As a result, it can make doing healthchecks for the service very difficult. Too short of a time and the container will be killed before the update is completed. Too long and the container takes forever to become healthy (which for k8s, means no traffic is allowed to it).

k8s supports startup probes for this reason. The liveness/readiness probes will not kick in until the startup probe passes. Meaning updates will not affect them.

This adds a "flag" file that k8s can check for to see if the server has actually started yet. Which will allow the following probes for k8s. The flag file is also in the save folder for the map to prevent it from be detected/used by other servers in the cluster.

```yml
livenessProbe:
  tcpSocket:
    port: rcon
  initialDelaySeconds: 5 # how long it takes rcon port to start listening
  timeoutSeconds: 1
  periodSeconds: 5
  failureThreshold: 3
  successThreshold: 1
readinessProbe:
  exec:
    command:
    - sh
    - -c
    - rcon -a 127.0.0.1:${RCON_PORT} -p ${SERVER_ADMIN_PASSWORD} listplayers
  initialDelaySeconds: 5 # how long after the rcon port starts listening the game server is "online"
  timeoutSeconds: 1
  periodSeconds: 5
  failureThreshold: 3
  successThreshold: 1
startupProbe:
  exec:
    command:
      - sh
      - -c
      - test ! -f "${ARK_PATH}/ShooterGame/Saved/SavedArks/${SERVER_MAP}/.pre-setup"
  initialDelaySeconds: 5
```